### PR TITLE
Add centralized inventory movement tracking

### DIFF
--- a/app/Http/Controllers/CotizacionController.php
+++ b/app/Http/Controllers/CotizacionController.php
@@ -10,13 +10,14 @@ use App\Models\Venta;
 use App\Enums\EstadoPedido;
 use App\Models\Cliente;
 use App\Models\Producto;
-use App\Models\Servicio;
-use App\Models\CotizacionItem;
 use App\Enums\EstadoCotizacion;
-use App\Services\MarginService;
+use App\Models\CotizacionItem;
+use App\Models\Servicio;
 use App\Models\SatEstado;
 use App\Models\SatRegimenFiscal;
 use App\Models\SatUsoCfdi;
+use App\Services\InventarioService;
+use App\Services\MarginService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Illuminate\Support\Facades\DB;
@@ -606,7 +607,17 @@ class CotizacionController extends Controller
                         'cantidad' => $item->cantidad,
                         'precio' => $item->precio,
                     ]);
-                    Producto::find($id)?->decrement('stock', $item->cantidad);
+                    $productoVenta = Producto::find($id);
+                    if ($productoVenta) {
+                        app(InventarioService::class)->salida($productoVenta, $item->cantidad, [
+                            'motivo' => 'Conversión de cotización a venta',
+                            'referencia' => $venta,
+                            'detalles' => [
+                                'cotizacion_id' => $cotizacion->id,
+                                'cotizacion_item_id' => $item->id,
+                            ],
+                        ]);
+                    }
                 } elseif ($class === Servicio::class) {
                     $venta->servicios()->attach($id, [
                         'cantidad' => $item->cantidad,

--- a/app/Models/InventarioMovimiento.php
+++ b/app/Models/InventarioMovimiento.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class InventarioMovimiento extends Model
+{
+    use HasFactory;
+
+    public const TIPO_ENTRADA = 'entrada';
+    public const TIPO_SALIDA = 'salida';
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'producto_id',
+        'tipo',
+        'cantidad',
+        'stock_anterior',
+        'stock_posterior',
+        'motivo',
+        'referencia_type',
+        'referencia_id',
+        'user_id',
+        'detalles',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'detalles' => 'array',
+    ];
+
+    /**
+     * @return BelongsTo<Producto, InventarioMovimiento>
+     */
+    public function producto(): BelongsTo
+    {
+        return $this->belongsTo(Producto::class);
+    }
+
+    /**
+     * @return MorphTo<Model, InventarioMovimiento>
+     */
+    public function referencia(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return BelongsTo<User, InventarioMovimiento>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Producto.php
+++ b/app/Models/Producto.php
@@ -83,6 +83,12 @@ class Producto extends Model
         return $this->hasMany(Inventario::class);
     }
 
+    /** @return HasMany<InventarioMovimiento> */
+    public function movimientos(): HasMany
+    {
+        return $this->hasMany(InventarioMovimiento::class);
+    }
+
     /* =========================================================================
      * Relaciones polimórficas UNIFICADAS a *items (coinciden con tus controladores)
      * ========================================================================= */

--- a/app/Services/InventarioService.php
+++ b/app/Services/InventarioService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\InventarioMovimiento;
+use App\Models\Producto;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use InvalidArgumentException;
+use RuntimeException;
+
+class InventarioService
+{
+    public function __construct(private readonly DatabaseManager $db)
+    {
+    }
+
+    public function entrada(Producto $producto, int $cantidad, array $contexto = []): InventarioMovimiento
+    {
+        return $this->ajustar($producto, InventarioMovimiento::TIPO_ENTRADA, $cantidad, $contexto);
+    }
+
+    public function salida(Producto $producto, int $cantidad, array $contexto = []): InventarioMovimiento
+    {
+        return $this->ajustar($producto, InventarioMovimiento::TIPO_SALIDA, $cantidad, $contexto);
+    }
+
+    protected function ajustar(Producto $producto, string $tipo, int $cantidad, array $contexto = []): InventarioMovimiento
+    {
+        if (!in_array($tipo, [InventarioMovimiento::TIPO_ENTRADA, InventarioMovimiento::TIPO_SALIDA], true)) {
+            throw new InvalidArgumentException('Tipo de movimiento inválido.');
+        }
+
+        if ($cantidad <= 0) {
+            throw new InvalidArgumentException('La cantidad del movimiento debe ser mayor que cero.');
+        }
+
+        return $this->db->transaction(function () use ($producto, $tipo, $cantidad, $contexto) {
+            $producto->refresh();
+            $stockAnterior = (int) $producto->stock;
+
+            $nuevoStock = $stockAnterior;
+            if ($tipo === InventarioMovimiento::TIPO_ENTRADA) {
+                $nuevoStock = $stockAnterior + $cantidad;
+            } else {
+                $nuevoStock = $stockAnterior - $cantidad;
+                if ($nuevoStock < 0) {
+                    throw new RuntimeException("Stock insuficiente para el producto '{$producto->nombre}'.");
+                }
+            }
+
+            $producto->forceFill(['stock' => $nuevoStock])->save();
+
+            $referencia = Arr::get($contexto, 'referencia');
+            $userId = Arr::get($contexto, 'user_id');
+            if (!$userId && $this->usuarioAutenticado()) {
+                $userId = Auth::id();
+            }
+
+            $movimientoData = [
+                'producto_id' => $producto->id,
+                'tipo' => $tipo,
+                'cantidad' => $cantidad,
+                'stock_anterior' => $stockAnterior,
+                'stock_posterior' => $nuevoStock,
+                'motivo' => Arr::get($contexto, 'motivo'),
+                'user_id' => $userId,
+                'detalles' => Arr::get($contexto, 'detalles'),
+            ];
+
+            if ($referencia) {
+                $movimientoData['referencia_type'] = get_class($referencia);
+                $movimientoData['referencia_id'] = $referencia->getKey();
+            }
+
+            return InventarioMovimiento::create($movimientoData);
+        });
+    }
+
+    protected function usuarioAutenticado(): bool
+    {
+        try {
+            return Auth::check();
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+}

--- a/database/migrations/2025_12_01_000000_create_inventario_movimientos_table.php
+++ b/database/migrations/2025_12_01_000000_create_inventario_movimientos_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('inventario_movimientos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('producto_id')->constrained()->cascadeOnDelete();
+            $table->enum('tipo', ['entrada', 'salida']);
+            $table->unsignedInteger('cantidad');
+            $table->integer('stock_anterior');
+            $table->integer('stock_posterior');
+            $table->string('motivo')->nullable();
+            $table->nullableMorphs('referencia');
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->json('detalles')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('inventario_movimientos');
+    }
+};


### PR DESCRIPTION
## Summary
- add an inventory movements migration, model, and service to centralize stock adjustments and metadata capture
- expose product-to-movement relations for reporting and auditing purposes
- refactor purchase, order, sales, and API flows to rely on the new inventory service so every stock change records a professional-grade movement entry

## Testing
- php -l app/Models/InventarioMovimiento.php
- php -l app/Services/InventarioService.php
- php -l app/Http/Controllers/CompraController.php
- php -l app/Http/Controllers/OrdenCompraController.php
- php -l app/Http/Controllers/CotizacionController.php
- php -l app/Http/Controllers/VentaController.php
- php -l app/Http/Controllers/PedidoController.php
- php -l app/Http/Controllers/Api/VentaController.php
- php -l app/Models/Producto.php
- php -l database/migrations/2025_12_01_000000_create_inventario_movimientos_table.php

------
https://chatgpt.com/codex/tasks/task_e_68db77fc6f50832cbc9996a136a22dee